### PR TITLE
[Fix] Prevent 13:37 Code to schedule when Bot doesn't run

### DIFF
--- a/src/listeners/message.ts
+++ b/src/listeners/message.ts
@@ -11,7 +11,6 @@ import {
 } from 'discord.js'
 import { ILogger } from '../logger/logger'
 import { containsKeywordFromArray, mentionsBot, greetings, sleepings } from './autoReactHelperFunctions'
-import schedule from 'node-schedule'
 
 function buildAttachmentList(attachments: Collection<string, Attachment>): string {
   let i = 0
@@ -26,25 +25,6 @@ function buildAttachmentList(attachments: Collection<string, Attachment>): strin
 
 export default async (client: Client, logger: ILogger): Promise<void> => {
   logger.logSync('INFO', 'Initializing message logger')
-
-  schedule.scheduleJob('37 13 * * *', async () => {
-    try {
-      const targetChannel = await client.channels.fetch(process.env.SEND_1337_CHANNEL_ID ?? '')
-
-      if (targetChannel && targetChannel.type === ChannelType.GuildText) {
-        await targetChannel.send('13:37')
-       // console.log('Message sent successfully');
-      }
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error('Error in sending message: ' + error.message)
-        logger.logSync('ERROR', 'Error in sending message: ' + error.message)
-      } else {
-        console.error('An unknown error occurred in sending the message')
-        logger.logSync('ERROR', 'An unknown error occurred in sending the message')
-      }
-    }
-  })
 
   client.on('messageCreate', async (msg) => {
     if (msg.author?.bot) return
@@ -112,7 +92,7 @@ export default async (client: Client, logger: ILogger): Promise<void> => {
       })
       newMsgEmbed.addFields({
         name: 'Attachments',
-        value: (newMsg.attachments.size > 0) ? buildAttachmentList(newMsg.attachments) : '<keine Anhänge/Medien>'
+        value: newMsg.attachments.size > 0 ? buildAttachmentList(newMsg.attachments) : '<keine Anhänge/Medien>'
       })
     }
 

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -1,5 +1,6 @@
-import { Client } from 'discord.js'
+import { ChannelType, Client } from 'discord.js'
 import { ILogger } from '../logger/logger'
+import schedule from 'node-schedule'
 
 export default (client: Client, logger: ILogger): void => {
   client.on('ready', async () => {
@@ -8,5 +9,17 @@ export default (client: Client, logger: ILogger): void => {
     }
 
     logger.logSync('INFO', `${client.user.username}#${client.user.discriminator} ist online!`)
+
+    // Everyday at 13:37 (24 hour clock)
+    schedule.scheduleJob('37 13 * * *', async () => {
+      const targetChannel = await client.channels.fetch(process.env.SEND_1337_CHANNEL_ID ?? '')
+
+      if (!targetChannel || targetChannel.type !== ChannelType.GuildText) {
+        logger.logSync('WARN', 'MessageLogger could not find log channel or LogChannel is not TextBased')
+        return
+      }
+
+      await targetChannel.send('13:37')
+    })
   })
 }


### PR DESCRIPTION
This commit addresses an issue where the 13:37 scheduling code gets run even tho the Bot does not run (ex. no token, no connection to discord), which would result in the github action to run the max time. (Which also means the bot does not get deployed)